### PR TITLE
Update GitHub Actions to use latest upload and deploy pages actions

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Static HTML export with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next export
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./out
 
@@ -91,4 +91,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary by Sourcery

Update the Next.js GitHub Actions workflow to use the latest upload and deploy pages actions.

CI:
- Upgrade actions/upload-pages-artifact from v1 to v3 in the Next.js workflow
- Upgrade actions/deploy-pages from v1 to v4 in the Next.js workflow